### PR TITLE
Feature removal, research tool adjustments

### DIFF
--- a/app/prompts/prompts.py
+++ b/app/prompts/prompts.py
@@ -5,10 +5,10 @@ from enum import Enum
 def get_system_prompt() -> str:
     return f"""
         ### STRICT PLANNING PROTOCOL:
-        1. **PRIMARY RULE (Tool Usage):** If you plan to use ANY tool (AnalyzeData, ExecuteCode, WebSearch, etc.), you MUST call the `InternalThought` tool FIRST. This is non-negotiable.
-        2. **EXCEPTION (No Tools):** Only if you are answering WITHOUT using any tools (e.g., simple greetings, basic factual responses from memory) may you skip the `InternalThought` tool.
-        3. **Complexity Consideration:** For complex queries or multi-step tasks, use `InternalThought` even if you're not immediately using tools, to plan your approach.
-        4. **Re-planning:** You may call `InternalThought` again if you need to adapt your plan after seeing tool results.
+        1. **PRIMARY RULE (Tool Usage):** If you plan to use ANY tool (AnalyzeData, ExecuteCode, WebSearch, etc.), plan your approach first. This is non-negotiable.
+        2. **EXCEPTION (No Tools):** Only if you are answering WITHOUT using any tools (e.g., simple greetings, basic factual responses from memory) may you skip explicit planning.
+        3. **Complexity Consideration:** For complex queries or multi-step tasks, explicitly plan your approach before taking actions.
+        4. **Re-planning:** Re-plan whenever tool results or new information require adaptation.
 
         ### REASONING RULES & CONSTRAINTS:
         1) Analyze logical dependencies and constraints (Rules 1.1 - 1.4).

--- a/app/services/chatbot_service.py
+++ b/app/services/chatbot_service.py
@@ -112,21 +112,6 @@ class ChatbotService:
                         # Add to the internal context regardless so LangChain can resolve it
                         context_tool_calls.append(tc)
 
-                        if tool_name == "InternalThought":
-                            thought_text = tool_args.get("reasoning", "")
-                            if thought_text:
-                                yield f"data: {json.dumps({'thought': thought_text}, ensure_ascii=False)}\n\n"
-                            
-                            # Let ToolExecutor handle it so logs/dispatch are centralized
-                            tasks.append(self.tool_executor.execute(
-                                tool_name, 
-                                json.dumps(tool_args), 
-                                self.session_id,
-                                self.store
-                            ))
-                            task_ids.append({"tool_id": tool_id, "tool_name": tool_name, "tool_args": tool_args, "is_thought": True})
-                            continue
-
                         # Only add non-thoughts to the persistent store
                         tool_calls_data_to_store.append({
                             "id": tool_id,
@@ -165,7 +150,7 @@ class ChatbotService:
                     for idx, tool_result in enumerate(tool_results):
                         tool_id = task_ids[idx]["tool_id"]
                         tool_name = task_ids[idx]["tool_name"]
-                        is_thought = task_ids[idx].get("is_thought", False)
+
                         
                         tool_result_content = ""
                         if isinstance(tool_result, Exception):
@@ -184,15 +169,13 @@ class ChatbotService:
                             name=tool_name
                         ))
 
-                        # Only persist non-thought tool results to the database
-                        if not is_thought:
-                            tool_msg_dict = {
-                                "role": "tool",
-                                "tool_call_id": tool_id,
-                                "name": tool_name,
-                                "content": tool_result_content
-                            }
-                            await self.store.add_message(self.session_id, tool_msg_dict)
+                        tool_msg_dict = {
+                            "role": "tool",
+                            "tool_call_id": tool_id,
+                            "name": tool_name,
+                            "content": tool_result_content,
+                        }
+                        await self.store.add_message(self.session_id, tool_msg_dict)
 
 
                     # Loop continues to get next response from LLM (using updated lc_messages)

--- a/app/services/langchain_handler/tool_definitions.py
+++ b/app/services/langchain_handler/tool_definitions.py
@@ -133,13 +133,9 @@ class DeepScholarResearchAndHighlight(BaseModel):
         "DO NOT return single words or keyword lists."))
     count: int = Field(default=5, description="The number of research papers to index. Default is 5.")
 
-class InternalThought(BaseModel):
-    """CONDITIONAL STEP. Use this tool to log your internal reasoning, planning, and risk assessments before taking any other action. Required for complex queries and before tool calls, but skip it for simple/direct greetings and basic questions."""
-    reasoning: str = Field(description="Your detailed internal thought process, hypothesis, and plan of action.")
 
 def get_tool_schemas():
     return [
-        InternalThought,
         AnalyzeData,
         ExecuteCode,
         ExtractMetadata,

--- a/app/services/langchain_handler/tool_definitions.py
+++ b/app/services/langchain_handler/tool_definitions.py
@@ -91,7 +91,7 @@ class FetchResearch(BaseModel):
     """
     
     query: str = Field(description="The user's research query to find relevant academic papers. This should be a natural language question or topic (e.g., 'What are the latest advancements in CRISPR gene editing?').")
-    count: int = Field(default=25, description="The number of research papers to return. Default is 25.")
+    count: int = Field(default=10, description="The number of research papers to return. Default is 10.")
     publication_year: Optional[str] = Field(
         default=">1950",
         description="Filter by year (e.g., '2023', '>2020', or '2020-2023'). Default is '>1950'."

--- a/app/services/langchain_handler/tool_executor.py
+++ b/app/services/langchain_handler/tool_executor.py
@@ -19,7 +19,6 @@ class ToolExecutor:
         """Dynamic tool dispatcher."""
         try:
             dispatch_map = {
-                "InternalThought": self._execute_internal_thought,
                 "WebSearch": self._execute_web_search,
                 "WebFetch": self._execute_web_fetch,
                 "WebResearch": self._execute_web_research,
@@ -53,10 +52,6 @@ class ToolExecutor:
             return f"Error executing {function_name}: {str(e)}"
 
     # --- Tool Implementation Wrappers ---
-
-    async def _execute_internal_thought(self, args, ctx):
-        """Acknowledges the reasoning was recorded."""
-        return "Thought recorded."
 
     async def _execute_web_search(self, args, ctx):
         query = args.pop("question")

--- a/app/services/scholar_research/openalex_service.py
+++ b/app/services/scholar_research/openalex_service.py
@@ -12,7 +12,7 @@ class OpenAlexResearchService(BaseResearchService):
         self.works_url = "https://api.openalex.org/works" 
 
 
-    async def semantic_scholar_search(self, query, count=25, publication_year=">1900", is_oa=True, has_pdf=True) -> list:
+    async def semantic_scholar_search(self, query, count=10, publication_year=">1900", is_oa=True, has_pdf=True) -> list:
         params = {
             "search": query,
             "per-page": min(count, 200),


### PR DESCRIPTION
This pull request removes the `InternalThought` tool and updates the planning protocol to generalize planning steps, as well as adjusts research tool defaults to return fewer papers. The most important changes are grouped below by theme.

**Planning and Tool Usage Protocol Updates:**

* The strict planning protocol in `get_system_prompt()` was revised to remove explicit references to the `InternalThought` tool, replacing it with a generalized planning requirement before tool usage.

**Removal of InternalThought Tool:**

* All code related to the `InternalThought` tool was removed, including its schema definition in `tool_definitions.py`, its dispatch logic and implementation in `tool_executor.py`, and handling in `chatbot_service.py`. [[1]](diffhunk://#diff-eda78ff81e776538f64d2fb253c655aa045e34fc505dbc8037ca968d5e68fe44L136-L142) [[2]](diffhunk://#diff-81bf34954707ba30f544e55c308b34e20addb004f546a1bb06f644a5edaf45acL22) [[3]](diffhunk://#diff-81bf34954707ba30f544e55c308b34e20addb004f546a1bb06f644a5edaf45acL57-L60) [[4]](diffhunk://#diff-f8563d700b404c79ef4db08428aff29a02111ce8e9e9be94a48a3d87d7895b2bL115-L129) [[5]](diffhunk://#diff-f8563d700b404c79ef4db08428aff29a02111ce8e9e9be94a48a3d87d7895b2bL187-R176) [[6]](diffhunk://#diff-f8563d700b404c79ef4db08428aff29a02111ce8e9e9be94a48a3d87d7895b2bL168-R153)

**Research Tool Defaults Adjustments:**

* The default number of research papers returned by `FetchResearch` and `semantic_scholar_search` was reduced from 25 to 10 to improve efficiency and relevance. [[1]](diffhunk://#diff-eda78ff81e776538f64d2fb253c655aa045e34fc505dbc8037ca968d5e68fe44L94-R94) [[2]](diffhunk://#diff-4cb2260a070788fa2e6ddb8d6d47b9391b2f7a036d140ded2e7413ecec249c0bL15-R15)